### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,13 @@ contract AnonymousIncidentReporting {
     // Struct to represent an incident report
     struct Report {
         uint256 id;
-        address reporter;
         string message;
         uint256 timestamp;
         bool isDecrypted;
     }
 
-    // Array to store incident reports
-    Report[] public incidentReports;
-
-    // Mapping to track if a reporter has submitted a report
-    mapping(address => bool) public hasReported;
+    // Mapping to store incident reports for each user
+    mapping(address => Report[]) public userReports;
 
     // Event to be emitted when a new incident report is submitted
     event IncidentReported(address indexed reporter, uint256 reportId);
@@ -104,19 +100,51 @@ contract AnonymousIncidentReporting {
      * to protect the anonymity of the reporter and the content of the report.
      */
     function submitIncidentReport(string memory _message) public {
-        // Ensure the reporter has not already submitted a report
-        require(!hasReported[msg.sender], "You have already submitted a report");
-
         // Create a new incident report
-        uint256 reportId = incidentReports.length;
-        incidentReports.push(Report(reportId, msg.sender, _message, block.timestamp, false));
-
-        // Mark reporter as having submitted a report
-        hasReported[msg.sender] = true;
+        uint256 reportId = userReports[msg.sender].length;
+        userReports[msg.sender].push(Report(reportId, _message, block.timestamp, false));
 
         // Emit the IncidentReported event
         emit IncidentReported(msg.sender, reportId);
     }
+
+    /**
+     * @dev Retrieves the content of a decrypted incident report.
+     * @param _reportId The ID of the incident report to retrieve.
+     * Developers should implement the necessary decryption logic
+     * based on the specific requirements of their project.
+     */
+    function getDecryptedReport(uint256 _reportId) public view returns (string memory) {
+        // Ensure the report ID is within valid range
+        require(_reportId < userReports[msg.sender].length, "Invalid report ID");
+
+        // Ensure the report has been marked as decrypted
+        require(userReports[msg.sender][_reportId].isDecrypted, "Report is not decrypted");
+
+        // Return the decrypted message (developers should implement decryption logic)
+        return userReports[msg.sender][_reportId].message;
+    }
+
+    /**
+     * @dev Allows the decryption of an incident report.
+     * @param _reportId The ID of the incident report to decrypt.
+     * Developers should implement the necessary decryption logic
+     * based on the specific requirements of their project.
+     */
+    function decryptReport(uint256 _reportId) public {
+        // Ensure the report ID is within valid range
+        require(_reportId < userReports[msg.sender].length, "Invalid report ID");
+
+        // Ensure the report has not been decrypted yet
+        require(!userReports[msg.sender][_reportId].isDecrypted, "Report is already decrypted");
+
+        // TODO: Implement decryption logic here
+
+        // Mark the report as decrypted
+        userReports[msg.sender][_reportId].isDecrypted = true;
+    }
+}
+
 
 
 ```


### PR DESCRIPTION
1. **User-Specific Reports:**
   - Changed from a single array (`incidentReports`) to a mapping (`userReports`) to store incident reports for each user, allowing users to submit multiple reports.

2. **Removed Redundant Mapping:**
   - Removed the `hasReported` mapping as it's no longer needed with the new user-specific report structure.

3. **Simplified Report Struct:**
   - Removed the `reporter` field from the `Report` struct since the reporter's address is now implied by the user-specific mapping.

4. **Updated Report ID Handling:**
   - Changed the way report IDs are assigned for each user, utilizing the length of the user's report array.

5. **Optimized Submit Function:**
   - Removed the check for whether a user has already reported, allowing users to submit multiple incident reports.